### PR TITLE
Add canonical URL link to improve SEO

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -77,6 +77,7 @@
 	/>
 
 	<link rel="icon" href={favicon} />
+	<link rel="canonical" href={`https://billsforynab.com${page.url.pathname}`} />
 
 	<!-- Open Graph -->
 	<meta property="og:site_name" content="Bills (For YNAB)" />


### PR DESCRIPTION
## Summary
Added a canonical URL link to the layout head to improve search engine optimization and prevent duplicate content issues.

## Changes
- Added canonical link tag that points to the current page's URL on billsforynab.com
- The canonical URL is dynamically generated based on the current page pathname using `page.url.pathname`

## Implementation Details
The canonical link is placed in the `<svelte:head>` section alongside other meta tags and links, ensuring it's included on every page of the application. This helps search engines understand the preferred version of a page and consolidates ranking signals for pages that may be accessible via multiple URLs.

https://claude.ai/code/session_01KfbisVHDruyBB2zzoYmnKx